### PR TITLE
Tweaks for Landsat harvester

### DIFF
--- a/config-landsat.yaml
+++ b/config-landsat.yaml
@@ -52,3 +52,6 @@ worker:
     LandsatRegisterMetadataHandler:
       stac_api_url: https://resource-catalogue.develop.eoepca.org/stac/
       stac_file_deletion: true
+      rewrite_asset_hrefs:
+        prefix_from: ""
+        prefix_to: "file://"

--- a/src/worker/common/client.py
+++ b/src/worker/common/client.py
@@ -4,11 +4,13 @@ from requests.auth import HTTPBasicAuth
 from worker.common.config import worker_config
 from worker.common.secrets import worker_secrets
 
+import certifi
+
 
 def customize_session(session):
     flowable_config = worker_config.get("flowable")
     if flowable_config.get("tls", False) and session is not None:
-        session.verify = flowable_config.get("cacert", "")
+        session.verify = flowable_config.get("cacert", certifi.where())
         return session
     else:
         return None

--- a/src/worker/landsat/tasks.py
+++ b/src/worker/landsat/tasks.py
@@ -352,7 +352,10 @@ class LandsatRegisterMetadataHandler(TaskHandler):
         if rewrite_asset_hrefs is not None:
             if "prefix_from" in rewrite_asset_hrefs and "prefix_to" in rewrite_asset_hrefs:
                 log_with_context(
-                    f"Rewriting asset hrefs with prefix {rewrite_asset_hrefs['prefix_from']} -> {rewrite_asset_hrefs['prefix_to']}",
+                    (
+                        "Rewriting asset hrefs with prefix "
+                        f"{rewrite_asset_hrefs['prefix_from']} -> {rewrite_asset_hrefs['prefix_to']}"
+                    ),
                     log_context,
                 )
             else:

--- a/src/worker/landsat/tasks.py
+++ b/src/worker/landsat/tasks.py
@@ -345,6 +345,24 @@ class LandsatRegisterMetadataHandler(TaskHandler):
         api_ca_cert = self.get_config("stac_api_ca_cert", None)
         file_deletion = self.get_config("stac_file_deletion", True)
 
+        # Asset href rewriting
+        # - By default - preserve existing behaviour - i.e. prefix 'file://'
+        rewrite_asset_hrefs_default = {"prefix_from": "", "prefix_to": "file://"}
+        rewrite_asset_hrefs = self.get_config("rewrite_asset_hrefs", rewrite_asset_hrefs_default)
+        if rewrite_asset_hrefs is not None:
+            if "prefix_from" in rewrite_asset_hrefs and "prefix_to" in rewrite_asset_hrefs:
+                log_with_context(
+                    f"Rewriting asset hrefs with prefix {rewrite_asset_hrefs['prefix_from']} -> {rewrite_asset_hrefs['prefix_to']}",
+                    log_context,
+                )
+            else:
+                rewrite_asset_hrefs = None
+                log_with_context(
+                    "Incomplete configuration for asset hrefs rewriting, skipping ...", log_context, "warning"
+                )
+        else:
+            log_with_context("No rewriting of asset hrefs configured", log_context)
+
         # validate input
         vars_not_set = self.validate([scene, scene_stac_file, api_url])
         if len(vars_not_set) > 0:
@@ -361,6 +379,7 @@ class LandsatRegisterMetadataHandler(TaskHandler):
                 api_pw=api_pw,
                 api_ca_cert=api_ca_cert,
                 file_deletion=file_deletion,
+                rewrite_asset_hrefs=rewrite_asset_hrefs,
             )
         except Exception as e:
             error_msg = str(e)

--- a/src/worker/landsat/tasks.py
+++ b/src/worker/landsat/tasks.py
@@ -223,7 +223,7 @@ class LandsatDownloadHandler(TaskHandler):
 
         base_dir = self.get_config("download_base_dir", "/tmp")
         download_timeout = self.get_config("download_timeout", 300)
-        temp_dir = usgs.get_scene_id_folder(scene["id"])
+        temp_dir = landsat.get_scene_id_folder(scene["id"])
         download_dir = os.path.join(base_dir, temp_dir)
         file_path = os.path.join(download_dir, f"{scene["id"]}.tar")
 


### PR DESCRIPTION
Fixes that worked for my local deployment - hopefully also relevant more generally.

**STAC `asset` href rewriting**
Added configurable prefixes for asset rewriting - as an alternative to the assumed `file://` prefix - allowing support for different asset delivery and system integration scenarios.
Defaults to the current `file://` prefix approach.

Additional fixes...

**tasks.py**
Fixing a python error I was getting.

**client.py**
Fixing tls verify behaviour - at least applicable to my local cluster - where I was getting massively verbose logging of `WARNING` that `session.verify` was disabled and this was a bad idea.
In my local cluster I have good TLS (letsencrypt) certs - so set values `tls: True` and `cacert` not set (i.e. rely upon system certs) - but this triggered the logic to set `session.verify=False` - leading to the aggressive `WARNING` logs.
The workaround for me was to set the default `cacert` value to that which would be used naturally by python (`certifi`).

