### PR TITLE
Fix some Sentinel harvesting problems so that it can be demonstrated in the tutorials and deployment guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 !/src
 !/etc/eoepca-ca-chain.pem
 !/tests/data
+!/etc/collections

--- a/src/worker/common/datasets/sentinel.py
+++ b/src/worker/common/datasets/sentinel.py
@@ -196,11 +196,6 @@ def create_metadata(scene_path, scene_id, return_pystac=False, add_file_size=Fal
         elif scene_id.startswith("S3"):
             stac_item = modify_s3_stac(stac_item, stac_collection)
 
-        # Add file:// protocol for local file paths
-        for asset in stac_item.assets:
-            if stac_item.assets[asset].href.startswith("/"):
-                stac_item.assets[asset].href = "file://%s" % stac_item.assets[asset].href
-
         if add_file_size:
             stac_item = add_asset_filesize(stac_item)
 

--- a/src/worker/common/resources/stac.py
+++ b/src/worker/common/resources/stac.py
@@ -179,8 +179,10 @@ def register_metadata(
 
         if r.status_code >= 300:
             raise Exception(
-                ("Error: %s request of product %s not successfull. " +
-                 "Status code: %s. Reason: %s. Response content: %s URL: %s")
+                (
+                    "Error: %s request of product %s not successfull. "
+                    + "Status code: %s. Reason: %s. Response content: %s URL: %s"
+                )
                 % (
                     api_action,
                     stac.id,

--- a/src/worker/common/resources/stac.py
+++ b/src/worker/common/resources/stac.py
@@ -179,7 +179,8 @@ def register_metadata(
 
         if r.status_code >= 300:
             raise Exception(
-                "Error: %s request of product %s not successfull. Status code: %s. Reason: %s. Response content: %s URL: %s"
+                ("Error: %s request of product %s not successfull. " +
+                 "Status code: %s. Reason: %s. Response content: %s URL: %s")
                 % (
                     api_action,
                     stac.id,

--- a/src/worker/common/resources/stac.py
+++ b/src/worker/common/resources/stac.py
@@ -9,6 +9,7 @@ from pystac.extensions.file import FileExtension
 from requests.auth import HTTPBasicAuth
 
 from worker.common.base.file import get_file_size, get_folder_size
+from worker.common.log_utils import log_with_context
 
 
 def extract_by_function_name(scene_path: str, function_name: str, stac_function_options: dict):
@@ -83,6 +84,30 @@ def add_asset_filesize(stac):
     return stac
 
 
+def validate_configured_prefix_rewrite(rewrite_config, log_context=None):
+    """
+    Given the prefix rewrite settings from the config return the rewrite to use
+    (default if rewrite_config is None).
+    """
+    # Asset href rewriting
+    # - By default - preserve existing behaviour - i.e. prefix 'file://'
+    rewrite_asset_hrefs = rewrite_config or {"prefix_from": "", "prefix_to": "file://"}
+    if "prefix_from" in rewrite_asset_hrefs and "prefix_to" in rewrite_asset_hrefs:
+        log_with_context(
+            (
+                "Rewriting asset hrefs with prefix "
+                f"{rewrite_asset_hrefs['prefix_from']} -> {rewrite_asset_hrefs['prefix_to']}"
+            ),
+            log_context,
+        )
+    else:
+        rewrite_asset_hrefs = None
+        log_with_context(
+            "Incomplete configuration for asset hrefs rewriting, skipping ...", log_context, "warning"
+        )
+
+    return rewrite_asset_hrefs
+
 def asset_hrefs_rewrite(stac_item, prefix_from, prefix_to):
     """
     Rewrite asset hrefs in a STAC item by replacing a given prefix with a new prefix.
@@ -95,6 +120,9 @@ def asset_hrefs_rewrite(stac_item, prefix_from, prefix_to):
     Returns:
         The updated pystac.Item object
     """
+    if prefix_from == prefix_to:
+        return stac_item
+
     for asset in stac_item.assets.values():
         if asset.href.startswith(prefix_from):
             asset.href = asset.href.replace(prefix_from, prefix_to, 1)
@@ -152,8 +180,8 @@ def register_metadata(
 
         if r.status_code >= 300:
             raise Exception(
-                "Error: %s request of product %s not successfull. Status code: %s. Reason: %s. Response content: %s"
-                % (api_action, stac.id, r.status_code, r.reason, r.content),
+                "Error: %s request of product %s not successfull. Status code: %s. Reason: %s. Response content: %s URL: %s"
+                % (api_action, stac.id, r.status_code, r.reason, r.content, f"{api_url}/collections/{stac.collection_id}/items"),
             )
         else:
             print("%s request of product %s in collection %s successfull." % (api_action, stac.id, stac.collection_id))

--- a/src/worker/common/resources/stac.py
+++ b/src/worker/common/resources/stac.py
@@ -102,11 +102,10 @@ def validate_configured_prefix_rewrite(rewrite_config, log_context=None):
         )
     else:
         rewrite_asset_hrefs = None
-        log_with_context(
-            "Incomplete configuration for asset hrefs rewriting, skipping ...", log_context, "warning"
-        )
+        log_with_context("Incomplete configuration for asset hrefs rewriting, skipping ...", log_context, "warning")
 
     return rewrite_asset_hrefs
+
 
 def asset_hrefs_rewrite(stac_item, prefix_from, prefix_to):
     """
@@ -181,7 +180,14 @@ def register_metadata(
         if r.status_code >= 300:
             raise Exception(
                 "Error: %s request of product %s not successfull. Status code: %s. Reason: %s. Response content: %s URL: %s"
-                % (api_action, stac.id, r.status_code, r.reason, r.content, f"{api_url}/collections/{stac.collection_id}/items"),
+                % (
+                    api_action,
+                    stac.id,
+                    r.status_code,
+                    r.reason,
+                    r.content,
+                    f"{api_url}/collections/{stac.collection_id}/items",
+                ),
             )
         else:
             print("%s request of product %s in collection %s successfull." % (api_action, stac.id, stac.collection_id))

--- a/src/worker/landsat/tasks.py
+++ b/src/worker/landsat/tasks.py
@@ -346,25 +346,7 @@ class LandsatRegisterMetadataHandler(TaskHandler):
         file_deletion = self.get_config("stac_file_deletion", True)
 
         # Asset href rewriting
-        # - By default - preserve existing behaviour - i.e. prefix 'file://'
-        rewrite_asset_hrefs_default = {"prefix_from": "", "prefix_to": "file://"}
-        rewrite_asset_hrefs = self.get_config("rewrite_asset_hrefs", rewrite_asset_hrefs_default)
-        if rewrite_asset_hrefs is not None:
-            if "prefix_from" in rewrite_asset_hrefs and "prefix_to" in rewrite_asset_hrefs:
-                log_with_context(
-                    (
-                        "Rewriting asset hrefs with prefix "
-                        f"{rewrite_asset_hrefs['prefix_from']} -> {rewrite_asset_hrefs['prefix_to']}"
-                    ),
-                    log_context,
-                )
-            else:
-                rewrite_asset_hrefs = None
-                log_with_context(
-                    "Incomplete configuration for asset hrefs rewriting, skipping ...", log_context, "warning"
-                )
-        else:
-            log_with_context("No rewriting of asset hrefs configured", log_context)
+        rewrite_asset_hrefs = self.get_config("rewrite_asset_hrefs", None)
 
         # validate input
         vars_not_set = self.validate([scene, scene_stac_file, api_url])

--- a/src/worker/landsat/tasks.py
+++ b/src/worker/landsat/tasks.py
@@ -274,7 +274,7 @@ class LandsatUntarHandler(TaskHandler):
             return self.task_failure("Untar failed", error_msg, result, retries=0)
 
         try:
-            (scene_path, tar_file_removed) = untar_file(tar_file, remove_tar=remove_tar, create_folder=create_folder)
+            scene_path, tar_file_removed = untar_file(tar_file, remove_tar=remove_tar, create_folder=create_folder)
         except Exception as e:
             error_msg = str(e)
             log_with_context(error_msg, log_context, "error")

--- a/src/worker/sentinel/tasks.py
+++ b/src/worker/sentinel/tasks.py
@@ -420,6 +420,9 @@ class SentinelRegisterMetadataHandler(TaskHandler):
             log_with_context("Invalid input variables", log_context)
             return result.failure()
 
+        # Asset href rewriting
+        rewrite_asset_hrefs = self.get_config("rewrite_asset_hrefs", None)
+
         try:
             stac.register_metadata(
                 stac_file=stac_item,
@@ -429,9 +432,10 @@ class SentinelRegisterMetadataHandler(TaskHandler):
                 api_pw=api_pw,
                 api_ca_cert=api_ca_cert,
                 file_deletion=file_deletion,
+                rewrite_asset_hrefs=rewrite_asset_hrefs,
             )
 
             return result.success()
         except Exception as e:
-            log_with_context(f"Error registering metadata: {str(e)}", log_context)
+            log_with_context(f"Error registering metadata: {str(e)} at URL {str(api_url)}", log_context)
             return result.failure()

--- a/tests/test_stac_common.py
+++ b/tests/test_stac_common.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+import pytest
+
+from worker.common.resources.stac import validate_configured_prefix_rewrite, asset_hrefs_rewrite
+
+
+@pytest.mark.parametrize(
+    "rewrite_config, in_url, out_url",
+    [({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/abc/def/ghi.test", "/def/def/ghi.test"),
+     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/xyz/def/ghi.test", "/xyz/def/ghi.test"),
+     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
+     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "", ""),
+
+     ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/abc/def/ghi.test", "/abc/def/ghi.test"),
+     ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
+
+     ({}, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
+     (None, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
+     ({"prefix_from": "", "prefix_to": ""}, "/abc/def/ghi.test", "/abc/def/ghi.test")]
+)
+def test_url_rewrite_applies_configured_change_correctly(rewrite_config, in_url, out_url):
+    stac_item = Mock()
+    stac_item.assets = {"a1": Mock()}
+    stac_item.assets["a1"].href = in_url
+
+    config = validate_configured_prefix_rewrite(rewrite_config)
+    asset_hrefs_rewrite(stac_item, config["prefix_from"], config["prefix_to"])
+
+    assert stac_item.assets["a1"].href == out_url

--- a/tests/test_stac_common.py
+++ b/tests/test_stac_common.py
@@ -7,17 +7,17 @@ from worker.common.resources.stac import validate_configured_prefix_rewrite, ass
 
 @pytest.mark.parametrize(
     "rewrite_config, in_url, out_url",
-    [({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/abc/def/ghi.test", "/def/def/ghi.test"),
-     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/xyz/def/ghi.test", "/xyz/def/ghi.test"),
-     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
-     ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "", ""),
-
-     ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/abc/def/ghi.test", "/abc/def/ghi.test"),
-     ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
-
-     ({}, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
-     (None, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
-     ({"prefix_from": "", "prefix_to": ""}, "/abc/def/ghi.test", "/abc/def/ghi.test")]
+    [
+        ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/abc/def/ghi.test", "/def/def/ghi.test"),
+        ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/xyz/def/ghi.test", "/xyz/def/ghi.test"),
+        ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
+        ({"prefix_from": "/abc/", "prefix_to": "/def/"}, "", ""),
+        ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/abc/def/ghi.test", "/abc/def/ghi.test"),
+        ({"prefix_from": "/abc/", "prefix_to": "/abc/"}, "/def/def/ghi.test", "/def/def/ghi.test"),
+        ({}, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
+        (None, "/abc/def/ghi.test", "file:///abc/def/ghi.test"),
+        ({"prefix_from": "", "prefix_to": ""}, "/abc/def/ghi.test", "/abc/def/ghi.test"),
+    ],
 )
 def test_url_rewrite_applies_configured_change_correctly(rewrite_config, in_url, out_url):
     stac_item = Mock()


### PR DESCRIPTION
Whilst trying to add Sentinel harvesting to the deployment guide and tutorials I encountered two problems which this PR fixes:

* Harvesting depends on the Sentinel 2 STAC Collection file `etc/collections/sentinel/sentinel-2-c1-l2a.json` which is not included in the Docker image, resulting in harvesting failing.
* The STAC Items added to the catalogue are served with file:// URLs because URL rewriting was not supported for CDSE.

There is a small change in behaviour to make the code slightly neater: configuringan empty rewrite_asset_hrefs will now use the default rewrite (prefixing with file://) instead of disabling rewriting. To disable rewriting requires `{"prefix_from": "", "prefix_to": ""}`.

I haven't been able to fully test Landsat harvesting with these changes because the USGS service always tells me my account isn't allowed to download the data files (the difficulty getting this to work is why I was adding Sentinel harvesting to the tutorial in the first place).
